### PR TITLE
switch to newer logging dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
             <version>567e1cd</version>
         </dependency>
         <dependency>
-            <groupId>io.github.microutils</groupId>
+            <groupId>com.github.MicroUtils</groupId>
             <artifactId>kotlin-logging</artifactId>
-            <version>1.4.6</version>
+            <version>3aedaa9310</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
the 1.4.6 version of kotlin-logging depends on an older kotlin stdlib, this is solved in the latest commit but not yet available in a release. As a temporary fix I changed the dependency to a jitpack commit dependency, once the 1.4.7 is out this can be switched back to the normal dependency.