### PR TITLE
FileUtilities: Fix the check for executable modes

### DIFF
--- a/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/FileUtilities.kt
+++ b/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/FileUtilities.kt
@@ -130,7 +130,7 @@ fun extractContentFromArchive(destinationDirectory: File, archiveInputStream: In
                     tarIn.copyTo(outStream)
                     val mode = (entry as TarArchiveEntry).mode
 
-                    if ((mode and 64) > 0) {
+                    if ((mode and 65) > 0) {
                         f.setExecutable(true, (mode and 1) == 0)
                     }
                     if (OsType.current == OsType.MACOS) {


### PR DESCRIPTION
In the first check we want to find out whether user or other are executable,
then later eventually limit that to user / owner only.