### PR TITLE
Cleaning up Tor class in preparation for ExternalTor features

### DIFF
--- a/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/NativeTor.kt
+++ b/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/NativeTor.kt
@@ -53,11 +53,11 @@ private const val PATH_NATIVE = "native/"
 private const val OS_UNSUPPORTED = "We don't support Tor on this OS"
 
 class NativeTor @JvmOverloads @Throws(TorCtlException::class) constructor(workingDirectory: File, bridgeLines: Collection<String>? = null, torrcOverrides: Torrc? = null)
-    : Tor(NativeContext(workingDirectory, torrcOverrides),
-        bridgeLines) {
+    : Tor(NativeContext(workingDirectory, torrcOverrides)) {
 	
-	    override fun bootstrap(secondsBeforeTimeOut: Int,
-                          numberOfRetries: Int): Control {
+    private val bridgeConfig: List<String> = bridgeLines?.filter { it.length > 10 } ?: emptyList()
+
+    override fun bootstrap(secondsBeforeTimeOut: Int, numberOfRetries: Int): Control {
         var control: TorController? = null
         try {
             for (retryCount in 1..numberOfRetries) {

--- a/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/NativeTor.kt
+++ b/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/NativeTor.kt
@@ -60,9 +60,10 @@ private const val HS_DIR = "HiddenServiceDir"
 
 private const val HOSTNAME_TIMEOUT = 30 * 1000                                       // Milliseconds
 
-class NativeTor @JvmOverloads @Throws(TorCtlException::class) constructor(workingDirectory: File, bridgeLines: Collection<String>? = null, torrcOverrides: Torrc? = null)
-    : Tor(NativeContext(workingDirectory, torrcOverrides)) {
+class NativeTor @JvmOverloads @Throws(TorCtlException::class) constructor(workingDirectory: File, bridgeLines: Collection<String>? = null, torrcOverrides: Torrc? = null) : Tor() {
 	
+	private val context : NativeContext = NativeContext(workingDirectory, torrcOverrides)
+
     private val bridgeConfig: List<String> = bridgeLines?.filter { it.length > 10 } ?: emptyList()
 
     override fun bootstrap(secondsBeforeTimeOut: Int, numberOfRetries: Int): Control {

--- a/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/Tor.kt
+++ b/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/Tor.kt
@@ -131,11 +131,9 @@ class Control(private val con: TorController) {
 internal data class HsContainer(internal val hostname: String, internal val handler: TorEventHandler)
 
 
-abstract class Tor @Throws(TorCtlException::class) protected constructor(protected val context: TorContext,
-                                                                         bridgeLines: Collection<String>? = null) {
+abstract class Tor @Throws(TorCtlException::class) protected constructor(protected val context: TorContext) {
 
     protected val eventHandler: TorEventHandler = TorEventHandler()
-    protected val bridgeConfig: List<String> = bridgeLines?.filter { it.length > 10 } ?: emptyList()
     private val control: Control = try {
         bootstrap()
     } catch (e: Exception) {
@@ -311,15 +309,6 @@ abstract class Tor @Throws(TorCtlException::class) protected constructor(protect
     }
 
     fun isHiddenServiceAvailable(onionUrl: String): Boolean = control.hsAvailable(onionUrl)
-
-
-    /**
-     * Returns the root directory in which the Tor Onion Proxy keeps its files.
-     * This is mostly intended for debugging purposes.
-     *
-     * @return Working directory for Tor Onion Proxy files
-     */
-    val workingDirectory: File get() = context.workingDirectory
 
     fun shutdown() {
         synchronized(control) {

--- a/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/Tor.kt
+++ b/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/Tor.kt
@@ -119,7 +119,7 @@ class Control(private val con: TorController) {
 internal data class HsContainer(internal val hostname: String, internal val handler: TorEventHandler)
 
 
-abstract class Tor @Throws(TorCtlException::class) protected constructor(protected val context: TorContext) {
+abstract class Tor @Throws(TorCtlException::class) protected constructor() {
 
     protected val eventHandler: TorEventHandler = TorEventHandler()
     protected val control: Control = try {


### PR DESCRIPTION
because there has been stuff inside the `Tor` class, that does not belong there when looking forward to a similar-API external tor.