### PR TITLE
Support for `armhf` and `arm64` architectures.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.berndpruenster.netlayer</groupId>
     <artifactId>parent</artifactId>
-    <version>0.6.5.2</version>
+    <version>0.6.6</version>
     <packaging>pom</packaging>
 
     <name>Netlayer</name>

--- a/tor.external/pom.xml
+++ b/tor.external/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.berndpruenster.netlayer</groupId>
         <artifactId>parent</artifactId>
-        <version>0.6.5.2</version>
+        <version>0.6.6</version>
     </parent>
 
     <artifactId>tor.external</artifactId>

--- a/tor.native/pom.xml
+++ b/tor.native/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.berndpruenster.netlayer</groupId>
         <artifactId>parent</artifactId>
-        <version>0.6.5.2</version>
+        <version>0.6.6</version>
     </parent>
 
     <artifactId>tor.native</artifactId>
@@ -32,6 +32,16 @@
         <dependency>
             <groupId>com.github.JesusMcCloud.tor-binary</groupId>
             <artifactId>tor-binary-linux64</artifactId>
+            <version>${tor-binary.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.JesusMcCloud.tor-binary</groupId>
+            <artifactId>tor-binary-linux-armhf</artifactId>
+            <version>${tor-binary.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.JesusMcCloud.tor-binary</groupId>
+            <artifactId>tor-binary-linux-arm64</artifactId>
             <version>${tor-binary.version}</version>
         </dependency>
         <dependency>

--- a/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/NativeTor.kt
+++ b/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/NativeTor.kt
@@ -44,6 +44,8 @@ private const val BINARY_TOR_LNX = "tor"
 private const val PATH_LNX = "linux/"
 private const val PATH_LNX64 = "${PATH_LNX}x64/"
 private const val PATH_LNX32 = "${PATH_LNX}x86/"
+private const val PATH_LNXARMHF = "${PATH_LNX}armhf/"
+private const val PATH_LNXARM64 = "${PATH_LNX}arm64/"
 private const val PATH_MACOS = "osx/"
 private const val PATH_MACOS64 = "${PATH_MACOS}x64/"
 private const val PATH_WIN = "windows/"
@@ -53,7 +55,7 @@ private const val PATH_NATIVE = "native/"
 private const val OS_UNSUPPORTED = "We don't support Tor on this OS"
 
 class NativeTor @JvmOverloads @Throws(TorCtlException::class) constructor(workingDirectory: File, bridgeLines: Collection<String>? = null, torrcOverrides: Torrc? = null, automaticShutdown : Boolean = true) : Tor() {
-	
+
 	private val context : NativeContext = NativeContext(workingDirectory, torrcOverrides)
 
     private val bridgeConfig: List<String> = bridgeLines?.filter { it.length > 10 } ?: emptyList()
@@ -151,6 +153,8 @@ class NativeContext(workingDirectory: File, overrides: Torrc?) : TorContext(work
             OsType.MACOS -> PATH_NATIVE + PATH_MACOS64
             OsType.LNX32 -> PATH_NATIVE + PATH_LNX32
             OsType.LNX64 -> PATH_NATIVE + PATH_LNX64
+            OsType.LNXARMHF -> PATH_NATIVE + PATH_LNXARMHF
+            OsType.LNXARM64 -> PATH_NATIVE + PATH_LNXARM64
             else -> throw  RuntimeException(OS_UNSUPPORTED)
         }
     }
@@ -159,7 +163,7 @@ class NativeContext(workingDirectory: File, overrides: Torrc?) : TorContext(work
         when (OsType.current) {
             OsType.WIN -> PATH_NATIVE + PATH_WIN
             OsType.MACOS -> PATH_NATIVE + PATH_MACOS
-            OsType.LNX32, OsType.LNX64 -> PATH_NATIVE + PATH_LNX
+            OsType.LNX32, OsType.LNX64, OsType.LNXARMHF, OsType.LNXARM64 -> PATH_NATIVE + PATH_LNX
             else -> throw  RuntimeException(OS_UNSUPPORTED)
         }
     }
@@ -167,7 +171,7 @@ class NativeContext(workingDirectory: File, overrides: Torrc?) : TorContext(work
 
     override val torExecutableFileName: String by lazy {
         when (OsType.current) {
-            OsType.LNX32, OsType.LNX64 -> BINARY_TOR_LNX
+            OsType.LNX32, OsType.LNX64, OsType.LNXARMHF, OsType.LNXARM64 -> BINARY_TOR_LNX
             OsType.WIN -> BINARY_TOR_WIN
             OsType.MACOS -> BINARY_TOR_MACOS
             else -> throw  RuntimeException(OS_UNSUPPORTED)
@@ -182,7 +186,7 @@ class NativeContext(workingDirectory: File, overrides: Torrc?) : TorContext(work
     override fun installFiles() {
         super.installFiles()
         when (OsType.current) {
-            OsType.WIN, OsType.LNX32, OsType.LNX64, OsType.MACOS -> extractContentFromArchive(workingDirectory,
+            OsType.WIN, OsType.LNX32, OsType.LNX64, OsType.LNXARMHF, OsType.LNXARM64, OsType.MACOS -> extractContentFromArchive(workingDirectory,
                     getByName(
                             pathToTorExecutable + FILE_ARCHIVE))
             else -> throw RuntimeException(OS_UNSUPPORTED)

--- a/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/TorContext.kt
+++ b/tor.native/src/main/kotlin/org/berndpruenster/netlayer/tor/TorContext.kt
@@ -238,7 +238,7 @@ abstract class TorContext @Throws(IOException::class) protected constructor(val 
         val environment = processBuilder.environment()
         environment.put("HOME", workingDirectory.absolutePath)
         when (OsType.current) {
-            OsType.LNX32, OsType.LNX64 ->
+            OsType.LNX32, OsType.LNX64, OsType.LNXARMHF, OsType.LNXARM64 ->
                 // We have to provide the LD_LIBRARY_PATH because when looking
                 // for dynamic libraries
                 // Linux apparently will not look in the current directory by

--- a/tor/pom.xml
+++ b/tor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.berndpruenster.netlayer</groupId>
         <artifactId>parent</artifactId>
-        <version>0.6.5.2</version>
+        <version>0.6.6</version>
     </parent>
 
     <artifactId>tor</artifactId>

--- a/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/OsType.kt
+++ b/tor/src/main/kotlin/org/berndpruenster/netlayer/tor/OsType.kt
@@ -40,6 +40,8 @@ import java.util.*
 enum class OsType { WIN,
     LNX32,
     LNX64,
+    LNXARMHF,
+    LNXARM64,
     MACOS,
     ANDROID;
 
@@ -86,6 +88,12 @@ enum class OsType { WIN,
                 if (unameOutput.compareTo("x86_64") == 0) {
                     return LNX64
                 }
+                if (unameOutput.matches(Regex("arm.+"))) {
+                    return LNXARMHF
+                }
+                if (unameOutput.compareTo("aarch64") == 0) {
+                    return LNXARM64
+                }
                 throw  RuntimeException("Could not understand uname output, not sure what bitness")
             } catch (e: IOException) {
                 throw  RuntimeException("Uname failure", e)
@@ -99,7 +107,6 @@ enum class OsType { WIN,
     }
 
     fun isUnixoid(): Boolean {
-        return listOf(LNX32, LNX64, MACOS).contains(this)
+        return listOf(LNX32, LNX64, LNXARMHF, LNXARM64, MACOS).contains(this)
     }
 }
-


### PR DESCRIPTION
Depends on https://github.com/JesusMcCloud/tor-binary/pull/3
Ref: https://github.com/bisq-network/bisq/issues/2861
